### PR TITLE
In useImage, switching to change event instead of input.

### DIFF
--- a/src/use-image.hook.js
+++ b/src/use-image.hook.js
@@ -51,7 +51,7 @@ export function useImage({processImgElement = noop, fileBlobToUrl = defaultFileB
       fileInputElement.type = 'file'
       fileInputElement.accept = '.jpg, .png, image/*'
       fileInputElement.multiple = false
-      fileInputElement.addEventListener('input', () => {
+      fileInputElement.addEventListener('change', () => {
         if (fileInputElement.files && fileInputElement.files.length > 0) {
           fileBlobToUrl(fileInputElement.files[0], imgUrl => {
             performCommandWithValue(imgUrl)


### PR DESCRIPTION
Inserting images wasn't working in safari and edge (see https://canopytax.atlassian.net/browse/BLUE-646), so I changed to the `change` event instead of the `input` event on the `<input type="file"/>` and it fixed it. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file where it says that the change event is supported