### PR TITLE
expand isActive to account for 'formatBlock' used in the case of h1/h2

### DIFF
--- a/src/use-document-query-command-state.hook.js
+++ b/src/use-document-query-command-state.hook.js
@@ -3,7 +3,7 @@ import {RichTextContext} from './rich-text-container.component.js'
 
 const defaultActiveInfo = {isActive: false, value: false}
 
-export function useDocumentQueryCommandState(commandName) {
+export function useDocumentQueryCommandState(commandName, tagName) {
   const [activeInfo, setActiveInfo] = useState(defaultActiveInfo)
   const richTextContext = useContext(RichTextContext)
 
@@ -20,7 +20,16 @@ export function useDocumentQueryCommandState(commandName) {
   function recheckActive() {
     const isActuallyActive = document.queryCommandState(commandName)
     const actualActiveValue = document.queryCommandValue(commandName)
-    if (isActuallyActive !== activeInfo.isActive || actualActiveValue !== activeInfo.value) {
+    if (tagName) {
+      const newIsActive = tagName === actualActiveValue // 'h1' === 'h1'
+      if (newIsActive !== activeInfo.isActive || actualActiveValue !== activeInfo.value) {
+        setActiveInfo({
+          isActive: tagName === actualActiveValue,
+          value: actualActiveValue
+        })
+      }
+    }
+    else if (isActuallyActive !== activeInfo.isActive || actualActiveValue !== activeInfo.value) {
       setActiveInfo({
         isActive: isActuallyActive,
         value: actualActiveValue,

--- a/src/use-document-query-command-state.hook.js
+++ b/src/use-document-query-command-state.hook.js
@@ -3,7 +3,7 @@ import {RichTextContext} from './rich-text-container.component.js'
 
 const defaultActiveInfo = {isActive: false, value: false}
 
-export function useDocumentQueryCommandState(commandName, tagName) {
+export function useDocumentQueryCommandState(commandName, activeValueMatch) {
   const [activeInfo, setActiveInfo] = useState(defaultActiveInfo)
   const richTextContext = useContext(RichTextContext)
 
@@ -18,18 +18,10 @@ export function useDocumentQueryCommandState(commandName, tagName) {
   }, [activeInfo, setActiveInfo])
 
   function recheckActive() {
-    const isActuallyActive = document.queryCommandState(commandName)
     const actualActiveValue = document.queryCommandValue(commandName)
-    if (tagName) {
-      const newIsActive = tagName === actualActiveValue // 'h1' === 'h1'
-      if (newIsActive !== activeInfo.isActive || actualActiveValue !== activeInfo.value) {
-        setActiveInfo({
-          isActive: tagName === actualActiveValue,
-          value: actualActiveValue
-        })
-      }
-    }
-    else if (isActuallyActive !== activeInfo.isActive || actualActiveValue !== activeInfo.value) {
+    const isActuallyActive = activeValueMatch ? activeValueMatch === actualActiveValue : document.queryCommandState(commandName)
+
+    if (isActuallyActive !== activeInfo.isActive || actualActiveValue !== activeInfo.value) {
       setActiveInfo({
         isActive: isActuallyActive,
         value: actualActiveValue,


### PR DESCRIPTION
Document.execCommand() accepts as a command (first param) `formatBlock`. In such a case the third param `Requires a tag-name string` such as `<H1>`. I am using this to create h1/h2/h3 whereas before I was trying to make do with bandicoot's `useFontSize`.

In checking for the active status of these three, a special case is needed in useDocumentQueryCommandState. We're no longer just trying to ask the document if queryCommandValue `bold` or `italic` is true or false. Now, we need to

1. Accept a param that helps us know the tag that we'll check the formatBlock for
2. Check if document.queryCommandValue('formatBlock') matches that tag
3. setActiveInfo if either isActive or value (which in the case of fBLock is going to be h1-h6, pre, address) are incorrect