### PR TITLE
Control button order issue

### DIFF
--- a/src/rich-text-container.component.js
+++ b/src/rich-text-container.component.js
@@ -9,6 +9,14 @@ export function RichTextContainer(props) {
   const newHTMLListenersRef = useRef([])
   const serializers = useRef([])
 
+  useEffect(() => {
+    const contentEditableElement = contextValue.getContentEditableElement();
+
+    if (contentEditableElement && contentEditableElement.innerHTML) {
+      contextValue.fireNewHTML();
+    }
+  }, [contextValue])
+
   contextValue.addSelectionChangedListener = listener => {
     selectionChangedListenersRef.current.push(listener)
   }

--- a/src/rich-text-editor.component.js
+++ b/src/rich-text-editor.component.js
@@ -129,7 +129,6 @@ export const RichTextEditor = forwardRef((props, editorRef) => {
   useEffect(() => {
     if (props.initialHTML) {
       divRef.current.innerHTML = props.initialHTML
-      richTextContext.fireNewHTML()
     }
   }, [])
 


### PR DESCRIPTION
Moves calling `fireNewHTML` for `initialHTML` out of the RichTextEditor and into the RichTextContainer in order to ensure that it gets called after 'newHTMLListeners' have been set up by custom hooks irregardless of where those hooks are used in components within the RichTextContainer.

Fixes #26 