### PR TITLE
adding option for external html sanitization

### DIFF
--- a/src/rich-text-container.component.js
+++ b/src/rich-text-container.component.js
@@ -75,6 +75,7 @@ const defaultContextValue = {
   addSerializer: noop,
   removeSerializer: noop,
   serialize: noop,
+  sanitizeHTML: noop,
 }
 
 export const RichTextContext = React.createContext(defaultContextValue)

--- a/src/rich-text-editor.component.js
+++ b/src/rich-text-editor.component.js
@@ -12,7 +12,7 @@ export const RichTextEditor = forwardRef((props, editorRef) => {
   const selectionRangeBeforeBlurRef = useRef(null)
   const {isFocused, setFocused} = useSynchronousFocusState()
   const bandicootId = useRef(globalBandicootId++)
-  const [lastSavedHTML, setLastSavedHTML] = useState(richTextContext.sanitizeHTML(props.initialHTML))
+  const [lastSavedHTML, setLastSavedHTML] = useState(richTextContext.sanitizeHTML(props.initialHTML, 'setLastSavedHTML'))
   const [hasSetInitialHTML, setHasSetInitialHTML] = useState(false);
 
   if (editorRef) {
@@ -28,7 +28,7 @@ export const RichTextEditor = forwardRef((props, editorRef) => {
     // https://developer.mozilla.org/en-US/docs/Web/Events/paste
     event.preventDefault()
     event.stopPropagation()
-    let paste = richTextContext.sanitizeHTML((window.clipboardData || event.clipboardData).getData('text/html'))
+    let paste = richTextContext.sanitizeHTML((window.clipboardData || event.clipboardData).getData('text/html'), 'pasteHTML')
     let newPaste = props.pasteFn(paste)
     if (newPaste !== false) {
       document.execCommand('insertHTML', null, newPaste)
@@ -187,7 +187,7 @@ export const RichTextEditor = forwardRef((props, editorRef) => {
 
   function setHTML(html) {
     emptyEditor()
-    divRef.current.innerHTML = richTextContext.sanitizeHTML(html)
+    divRef.current.innerHTML = richTextContext.sanitizeHTML(html, 'setHTML')
     focus()
     richTextContext.fireNewHTML()
   }
@@ -197,7 +197,7 @@ export const RichTextEditor = forwardRef((props, editorRef) => {
   }
 
   function getHTML() {
-    return richTextContext.sanitizeHTML(serialize())
+    return richTextContext.sanitizeHTML(serialize(), 'getHTML')
   }
 
   function focus() {

--- a/src/use-content-editable-false.hook.js
+++ b/src/use-content-editable-false.hook.js
@@ -13,7 +13,7 @@ export function useContentEditableFalse({processContentEditableFalseElement = no
   return {
     insertContentEditableFalseElement(innerHTML) {
       const id = "rte-ce-false-temp-id-" + tempId++
-      const htmlToInsert = `<span id="${id}">${richTextContext.sanitizeHTML(innerHTML)}</span>`
+      const htmlToInsert = `<span id="${id}">${richTextContext.sanitizeHTML(innerHTML, 'insertContentEditableFalseHTML')}</span>`
       performCommandWithValue(htmlToInsert)
       const contentEditableFalseElement = document.getElementById(id)
       handleContentEditableFalseElement(contentEditableFalseElement)

--- a/src/use-content-editable-false.hook.js
+++ b/src/use-content-editable-false.hook.js
@@ -13,7 +13,7 @@ export function useContentEditableFalse({processContentEditableFalseElement = no
   return {
     insertContentEditableFalseElement(innerHTML) {
       const id = "rte-ce-false-temp-id-" + tempId++
-      const htmlToInsert = `<span id="${id}">${innerHTML}</span>`
+      const htmlToInsert = `<span id="${id}">${richTextContext.sanitizeHTML(innerHTML)}</span>`
       performCommandWithValue(htmlToInsert)
       const contentEditableFalseElement = document.getElementById(id)
       handleContentEditableFalseElement(contentEditableFalseElement)


### PR DESCRIPTION
Adding option for external html sanitization.  Modified reading, writing, and pasting HTML related functions.  If no sanitizeHTML function is provided, no sanitization happens: i.e. `value => value`