### PR TITLE
fixing issues with setting font size

### DIFF
--- a/src/use-font-size.hook.js
+++ b/src/use-font-size.hook.js
@@ -33,10 +33,11 @@ export function useFontSize({defaultFontSize = '14px', fontSizes}) {
       function selectionChanged() {
         const selection = window.getSelection()
         // If the selection has 'actually' changed (i.e. not just due to the editor bluring and focusing)
-        if (lastSelection === null
-          || !selection.anchorNode.isSameNode(lastSelection.anchorNode)
+        if (
+          !lastSelection
+          || selection.anchorNode !== lastSelection.anchorNode
           || selection.anchorOffset !== lastSelection.anchorOffset
-          || !selection.focusNode.isSameNode(lastSelection.focusNode)
+          || selection.focusNode !== lastSelection.focusNode
           || selection.focusOffset !== lastSelection.focusOffset
         ) {
           setLastSelection({

--- a/src/use-font-size.hook.js
+++ b/src/use-font-size.hook.js
@@ -7,6 +7,7 @@ export function useFontSize({defaultFontSize = '14px', fontSizes}) {
     throw Error(`Browsers only support up to 7 font sizes with document.execCommand('fontSize', null, size)`)
   }
   const [fontSize, setFontSize] = useState(defaultFontSize)
+  const [lastSelection, setLastSelection] = useState(null)
   const {performCommandWithValue} = useDocumentExecCommand('fontSize')
   const richTextContext = useContext(RichTextContext)
   const currentlySelectedFontSize = useCurrentlySelectedFontSize()
@@ -31,21 +32,36 @@ export function useFontSize({defaultFontSize = '14px', fontSizes}) {
 
       function selectionChanged() {
         const selection = window.getSelection()
-        // If there is no selection, we won't change the font size
-        if (selection.rangeCount > 0) {
-          let selectionNode = selection.getRangeAt(0).startContainer
-          if (selectionNode.nodeType !== 1) {
-            // we've got a text node or comment node or other type of node that's not an element
-            selectionNode = selectionNode.parentElement
-          }
-          const stringFontSize = window.getComputedStyle(selectionNode).fontSize
-          const newSize = stringFontSize
-          if (newSize !== fontSize) {
-            setFontSize(newSize)
+        // If the selection has 'actually' changed (i.e. not just due to the editor bluring and focusing)
+        if (lastSelection === null
+          || !selection.anchorNode.isSameNode(lastSelection.anchorNode)
+          || selection.anchorOffset !== lastSelection.anchorOffset
+          || !selection.focusNode.isSameNode(lastSelection.focusNode)
+          || selection.focusOffset !== lastSelection.focusOffset
+        ) {
+          setLastSelection({
+            anchorNode: selection.anchorNode,
+            anchorOffset: selection.anchorOffset,
+            focusNode: selection.focusNode,
+            focusOffset: selection.focusOffset
+          })
+
+          // If there is no selection, we won't change the font size
+          if (selection.rangeCount > 0) {
+            let selectionNode = selection.getRangeAt(0).startContainer
+            if (selectionNode.nodeType !== 1) {
+              // we've got a text node or comment node or other type of node that's not an element
+              selectionNode = selectionNode.parentElement
+            }
+            const stringFontSize = window.getComputedStyle(selectionNode).fontSize
+            const newSize = stringFontSize
+            if (newSize !== fontSize) {
+              setFontSize(newSize)
+            }
           }
         }
       }
-    }, [fontSize, setFontSize])
+    }, [fontSize, setFontSize, lastSelection])
 
     return fontSize
   }

--- a/src/use-font-size.hook.js
+++ b/src/use-font-size.hook.js
@@ -19,6 +19,7 @@ export function useFontSize({defaultFontSize = '14px', fontSizes}) {
       if (integerSize <= 0) {
         throw Error(`Cannot set font size since '${fontSize}' was not passed in the fontSizes array`)
       }
+      setFontSize(fontSize)
       performCommandWithValue(integerSize)
     },
   }


### PR DESCRIPTION
**Issue:**  When a user uses the 'setSize' function to manually set the font size if there isn't highlighted/selected text, the most recently selected font size is not immediately shown to the user because of how/when the `useCurrentlySelectedFontSize()` useEffect is getting called.

**Proposed Fix:** When using the 'setSize' function to manually set the font size, the `setFontSize` state setter needs called.  We also need to better determine what is a 'selectionchange' event by looking to see if the selected html has actually changed as opposed to just relying on the document's 'selectionchange' event which is fired when the editor itself is blurred and then refocused.