### PR TITLE
pasting is always providing plain text

### DIFF
--- a/src/rich-text-editor.component.js
+++ b/src/rich-text-editor.component.js
@@ -28,7 +28,7 @@ export const RichTextEditor = forwardRef((props, editorRef) => {
     // https://developer.mozilla.org/en-US/docs/Web/Events/paste
     event.preventDefault()
     event.stopPropagation()
-    let paste = richTextContext.sanitizeHTML((window.clipboardData || event.clipboardData).getData('text/plain'), 'pasteHTML')
+    let paste = richTextContext.sanitizeHTML((window.clipboardData || event.clipboardData).getData('text/html'), 'pasteHTML')
     let newPaste = props.pasteFn(paste)
     if (newPaste !== false) {
       document.execCommand('insertHTML', null, newPaste)


### PR DESCRIPTION
This changes paste behavior to match the docs which indicate that paste behavior is always html

https://bandicoot.js.org/concepts/pasting.html