### PR TITLE
Adding ref to RichTextEditor types

### DIFF
--- a/typings/bandicoot.d.ts
+++ b/typings/bandicoot.d.ts
@@ -26,7 +26,7 @@ declare module "bandicoot" {
     style?: object;
     placeholder?: string;
     placeholderColor?: string;
-    ref: React.RefObject<HTMLElement>;
+    ref?: React.RefObject<HTMLElement>;
   }
 
   type RichTextContextValue = {

--- a/typings/bandicoot.d.ts
+++ b/typings/bandicoot.d.ts
@@ -26,6 +26,7 @@ declare module "bandicoot" {
     style?: object;
     placeholder?: string;
     placeholderColor?: string;
+    ref: React.RefObject<HTMLElement>;
   }
 
   type RichTextContextValue = {


### PR DESCRIPTION
RichTextEditor forwards its ref to the contenteditable div. This adds that to the typescript definitions.