### PR TITLE
Fixing problem with typings for save() prop

### DIFF
--- a/typings/bandicoot.d.ts
+++ b/typings/bandicoot.d.ts
@@ -18,7 +18,7 @@ declare module "bandicoot" {
 
   type RichTextEditorProps = {
     initialHTML?: any;
-    save?(): any;
+    save?(html: string): any;
     sanitizeHTML?(html: string): string;
     pasteFn?(paste: string): string;
     unchangedInterval?: number;


### PR DESCRIPTION
See https://github.com/CanopyTax/bandicoot/blob/master/src/rich-text-editor.component.js#L175