### PR TITLE
Defaulting to opening links in a new tab

### DIFF
--- a/src/use-link.hook.js
+++ b/src/use-link.hook.js
@@ -39,7 +39,7 @@ export function useLink({processAnchorElement = noop} = defaultOptions) {
   function insertLink(link, displayedText) {
     richTextContext.selectRangeFromBeforeBlur({usePreviousRange: true})
     const id = `rte-link-temp-id-${tempId++}`
-    performCommandWithValue(`<a href="${link}" id="${id}">${displayedText}</a>`)
+    performCommandWithValue(`<a href="${link}" id="${id}" target="_blank">${displayedText}</a>`)
     const anchorElement = document.getElementById(id)
     anchorElement.removeAttribute('id')
     processAnchorElement(anchorElement)

--- a/src/use-link.hook.js
+++ b/src/use-link.hook.js
@@ -39,7 +39,7 @@ export function useLink({processAnchorElement = noop} = defaultOptions) {
   function insertLink(link, displayedText) {
     richTextContext.selectRangeFromBeforeBlur({usePreviousRange: true})
     const id = `rte-link-temp-id-${tempId++}`
-    performCommandWithValue(`<a href="${link}" id="${id}" target="_blank">${displayedText}</a>`)
+    performCommandWithValue(`<a href="${link}" id="${id}" target="_blank" rel="noopener noreferrer">${displayedText}</a>`)
     const anchorElement = document.getElementById(id)
     anchorElement.removeAttribute('id')
     processAnchorElement(anchorElement)


### PR DESCRIPTION
Note that this only applies when the link is innerHTML'ed outside of the rich text editor. Within the rich text editor, clicking on the link never takes you to the link. I think it's generally a better UX for displayed links to open in a new tab instead of leaving the current application.