### PR TITLE
Fixing typo

### DIFF
--- a/src/use-text-as-image.hook.js
+++ b/src/use-text-as-image.hook.js
@@ -3,7 +3,7 @@ import {useDocumentExecCommand} from './use-document-exec-command.hook.js'
 import {RichTextContext} from './rich-text-container.component.js'
 
 const noop = () => {}
-const defaultOptions = {processSerializedElement: noop, fontFamily: null, fillStyle: '#00bf4b', fontWeight: 'bold', textTop: null, backgroundColor: 'transparent'}
+const defaultOptions = {processSerializedElement: noop, fontFamily: null, fillStyle: '#00bf4b', fontWeight: 'bold', textBottom: null, backgroundColor: 'transparent'}
 
 export function useTextAsImage({processSerializedElement = noop, fontFamily, fillStyle, fontWeight, textBottom, backgroundColor} = defaultOptions) {
   const {performCommandWithValue} = useDocumentExecCommand('insertImage')


### PR DESCRIPTION
The option is called `textBottom`, not text top. Note that this typo didn't cause any bugs so it's okay to merge this without republishing.