### PR TITLE
Switch to useLayoutEffect for dom operations

### DIFF
--- a/src/rich-text-editor.component.js
+++ b/src/rich-text-editor.component.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useRef, useContext, forwardRef} from 'react'
+import React, {useState, useEffect, useRef, useContext, forwardRef, useLayoutEffect} from 'react'
 import {RichTextContext} from './rich-text-container.component.js'
 
 const noop = () => {}
@@ -46,7 +46,7 @@ export const RichTextEditor = forwardRef((props, editorRef) => {
     }
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     divRef.current.addEventListener('paste', interceptPaste)
     return () => divRef.current.removeEventListener('paste', interceptPaste)
   }, [props.pasteFn])
@@ -68,7 +68,7 @@ export const RichTextEditor = forwardRef((props, editorRef) => {
     selection.addRange(range)
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     document.addEventListener('selectionchange', handleSelectionChange)
     return () => document.removeEventListener('selectionchange', handleSelectionChange)
   })


### PR DESCRIPTION
cc @dvnrsn. This fixes a bug that I think was maybe caused by upgrading to React 17, where it says Cannot read property removeEventListener of undefined. I think the bug is caused by `useEffect` being cleaned up after dom operations are finished, which destroys the refs and dom elements stored in refs. By switching to `useLayoutEffect`, we clean up our event listeners before the ref and dom elements are destroyed.